### PR TITLE
Adding idotless to the tone mark substitution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,30 +19,17 @@ jobs:
         sudo apt-get update
         sudo apt-get install ttfautohint libcairo2-dev python3-cairo-dev pkg-config python3-dev
         sudo snap install yq
-    - uses: actions/cache@v4
-      with:
-        path: ./venv/
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # Ensure fonttools is present regardless
+        pip install fonttools
     - name: gen zip file name
       id: zip-name
       shell: bash
       # Set the archive name to repo name + "-assets" e.g "MavenPro-assets"
       run: echo "ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-fonts" >> $GITHUB_ENV
-
-    # If a new release is cut, use the release tag to auto-bump the source files
-    # - name: Bump release
-    #   if: github.event_name == 'release'
-    #   run: |
-    #     . venv/bin/activate
-    #     SRCS=$(yq e ".sources[]" sources/config.yaml)
-    #     TAG_NAME=${GITHUB_REF/refs\/tags\//}
-    #     echo "Bumping $SRCS to $TAG_NAME"
-    #     for src in $SRCS
-    #     do
-    #       bumpfontversion sources/$src --new-version $TAG_NAME;
-    #     done
 
     - name: Build font
       run: make build

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,4 @@ drawbot-skia>=0.5.0
 sh>=2.0.6
 bumpfontversion>=0.4.1
 diffenator2>=0.3.8
-fontTools
+fonttools

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,4 @@ drawbot-skia>=0.5.0
 sh>=2.0.6
 bumpfontversion>=0.4.1
 diffenator2>=0.3.8
-fonttools
+fontTools

--- a/sources/Huninn.glyphspackage/fontinfo.plist
+++ b/sources/Huninn.glyphspackage/fontinfo.plist
@@ -1,5 +1,5 @@
 {
-.appVersion = "3151";
+.appVersion = "3436";
 .formatVersion = 3;
 customParameters = (
 {
@@ -198,7 +198,7 @@ lookup ccmp_tl_poj {
 	# 2th tone of TL, POJ
 	sub a acutecomb by aacute;
 	sub e acutecomb by eacute;
-	sub i acutecomb by iacute;
+	sub [i idotless] acutecomb by iacute;
 	sub idotless acutecomb by iacute;
 	sub o acutecomb by oacute;
 	sub u acutecomb by uacute;
@@ -219,7 +219,7 @@ lookup ccmp_tl_poj {
 	# 3th tone of TL, POJ
 	sub a gravecomb by agrave;
 	sub e gravecomb by egrave;
-	sub i gravecomb by igrave;
+	sub [i idotless] gravecomb by igrave;
 	sub idotless gravecomb by igrave;
 	sub o gravecomb by ograve;
 	sub u gravecomb by ugrave;
@@ -240,7 +240,7 @@ lookup ccmp_tl_poj {
 	# 5th tone of TL, POJ
 	sub a circumflexcomb by acircumflex;
 	sub e circumflexcomb by ecircumflex;
-	sub i circumflexcomb by icircumflex;
+	sub [i idotless] circumflexcomb by icircumflex;
 	sub idotless circumflexcomb by icircumflex;
 	sub o circumflexcomb by ocircumflex;
 	sub u circumflexcomb by ucircumflex;
@@ -261,7 +261,7 @@ lookup ccmp_tl_poj {
 	# 6th tone of TL
 	sub a caroncomb by acaron;
 	sub e caroncomb by ecaron;
-	sub i caroncomb by icaron;
+	sub [i idotless] caroncomb by icaron;
 	sub idotless caroncomb by icaron;
 	sub o caroncomb by ocaron;
 	sub u caroncomb by ucaron;
@@ -282,7 +282,7 @@ lookup ccmp_tl_poj {
 	# 7th tone of TL, POJ
 	sub a macroncomb by amacron;
 	sub e macroncomb by emacron;
-	sub i macroncomb by imacron;
+	sub [i idotless] macroncomb by imacron;
 	sub idotless macroncomb by imacron;
 	sub o macroncomb by omacron;
 	sub u macroncomb by umacron;
@@ -303,7 +303,7 @@ lookup ccmp_tl_poj {
 	# 8th tone of TL, POJ
 	sub a verticallineabovecomb by a_verticallineabovecomb;
 	sub e verticallineabovecomb by e_verticallineabovecomb;
-	sub i verticallineabovecomb by i_verticallineabovecomb;
+	sub [i idotless] verticallineabovecomb by i_verticallineabovecomb;
 	sub idotless verticallineabovecomb by i_verticallineabovecomb;
 	sub o verticallineabovecomb by o_verticallineabovecomb;
 	sub u verticallineabovecomb by u_verticallineabovecomb;
@@ -325,7 +325,7 @@ lookup ccmp_tl_poj {
 	# 9th tone of TL
 	sub a hungarumlautcomb by a_hungarumlautcomb;
 	sub e hungarumlautcomb by e_hungarumlautcomb;
-	sub i hungarumlautcomb by i_hungarumlautcomb;
+	sub [i idotless] hungarumlautcomb by i_hungarumlautcomb;
 	sub idotless hungarumlautcomb by i_hungarumlautcomb;
 	sub o hungarumlautcomb by ohungarumlaut;
 	sub u hungarumlautcomb by uhungarumlaut;
@@ -346,7 +346,7 @@ lookup ccmp_tl_poj {
 	# 9th tone of POJ
 	sub a brevecomb by abreve;
 	sub e brevecomb by ebreve;
-	sub i brevecomb by ibreve;
+	sub [i idotless] brevecomb by ibreve;
 	sub idotless brevecomb by ibreve;
 	sub o brevecomb by obreve;
 	sub u brevecomb by ubreve;
@@ -14985,5 +14985,5 @@ y_caroncomb = {
 };
 };
 versionMajor = 1;
-versionMinor = 3;
+versionMinor = 4;
 }

--- a/sources/post.py
+++ b/sources/post.py
@@ -1,7 +1,7 @@
 import glob
 from pathlib import Path
-from fonttools.ttLib import TTFont
-from fonttools.ttLib.tables._v_h_e_a import table__v_h_e_a
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._v_h_e_a import table__v_h_e_a
 
 for file in Path("fonts").glob("**/*.ttf"):
     font = TTFont(str(file))

--- a/sources/post.py
+++ b/sources/post.py
@@ -1,7 +1,7 @@
 import glob
 from pathlib import Path
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.tables._v_h_e_a import table__v_h_e_a
+from fonttools.ttLib import TTFont
+from fonttools.ttLib.tables._v_h_e_a import table__v_h_e_a
 
 for file in Path("fonts").glob("**/*.ttf"):
     font = TTFont(str(file))


### PR DESCRIPTION
As both i and idotless can appear next to tone marks, better to include both than just one just in case.

This can be observed with the strings from: https://en.wikipedia.org/wiki/T%C3%A2i-u%C3%A2n_L%C3%B4-m%C3%A1-j%C4%AB_Phing-im_Hong-%C3%A0n#Sample_texts

Added to feature code, bumped version string. 